### PR TITLE
Add support for local plugins

### DIFF
--- a/template/prepare.js
+++ b/template/prepare.js
@@ -14,7 +14,8 @@ function copyNativeScriptPlugins () {
   const plugins = Object.keys(appPackage.dependencies)
     .filter(key => key.indexOf('nativescript-') !== -1)
     .reduce((obj, key) => {
-      obj[key] = appPackage.dependencies[key];
+      const dep = appPackage.dependencies[key];
+      obj[key] = dep.indexOf('file:') === 0 ? 'file:../' + dep.slice(5) : dep;
       return obj;
     }, {});
   Object.assign(tplPackage.dependencies, plugins);


### PR DESCRIPTION
Sometimes a local version of a plugin can be used, eg "file:nativescript-svg.3.x.x.tgz".  In this case, the dependency was not copied across correctly.  This simply adjusts the path, so the install within dist works correctly.