### PR TITLE
Copy the hooks folder into dist

### DIFF
--- a/template/prepare.js
+++ b/template/prepare.js
@@ -5,6 +5,7 @@ const winston = require('winston-color');
 
 const distPath = path.resolve(__dirname, './dist');
 const tplPath = path.resolve(__dirname, './template');
+const hooksPath = path.resolve(__dirname, './hooks');
 
 const appPackage = require('./package.json');
 const tplPackage = require('./template/package.json');
@@ -25,6 +26,9 @@ function updateDistFromTemplate () {
   winston.info('Preparing NativeScript application from template...');
   fs.ensureDirSync(distPath);
   fs.copySync(tplPath, distPath, {overwrite: false});
+  if (fs.existsSync(hooksPath)) {
+    fs.copySync(hooksPath, path.join(distPath, "hooks"));
+  }
   execSync('npm i', {cwd: 'dist'});
 }
 


### PR DESCRIPTION
Many plugins use hooks to run before/after prepare scripts. Firebase being one of those. This change copies the hooks folder (if any) to the dist folder. Without this change, the Firebase plugin will not run at all on Android and have trouble with certain features on iOS.

Also, users can now add their own hooks to the root /hooks folder, and those are picked up as well.

Note that this feature was added in #6, but it seems it got lost in recent refactorings.