### PR TITLE
Added the '@' alias to webpack config

### DIFF
--- a/template/webpack.config.js
+++ b/template/webpack.config.js
@@ -80,6 +80,9 @@ const config = (platform, launchArgs) => {
     },
 
     resolve: {
+      alias: {
+        '@': path.resolve(__dirname, './src'),
+      },
       modules: [
         'node_modules/tns-core-modules',
         'node_modules',


### PR DESCRIPTION
Hugely helps with imports because everything doesn't need to be relative to the current file anymore. You have a nice alias '@' that points to the 'src' dir.