### PR TITLE
Fix spelling error in main.js

### DIFF
--- a/template/src/main.js
+++ b/template/src/main.js
@@ -16,7 +16,7 @@ import store from './store';
 
 import './styles.scss';
 
-// Uncommment the following to see NativeScript-Vue output logs
+// Uncomment the following to see NativeScript-Vue output logs
 //Vue.config.silent = false;
 
 new Vue({


### PR DESCRIPTION
Just noticed a spelling error in the comment on line 19 in `template/src/main.js`. This just fixes that small typo.