### PR TITLE
Solve error "Cannot read property 'split' of undefined" running "npm …

### DIFF
--- a/template/webpack.config.js
+++ b/template/webpack.config.js
@@ -160,7 +160,7 @@ module.exports = env => {
   const action = (!env || !env.tnsAction) ? 'build' : env.tnsAction;
 
   if (!env || (!env.android && !env.ios)) {
-    return [config('android'), config('ios', action)];
+    return [config('android', action), config('ios', action)];
   }
 
   return env.android && config('android', `${action} android`)


### PR DESCRIPTION
…run watch"

On MacOS running "npm run watch" results in throwing an error "Cannot read property 'split' of undefined". Adding action for android config function solves it.