### PR TITLE
Default value on launchArgs

### DIFF
--- a/template/webpack.config.js
+++ b/template/webpack.config.js
@@ -12,7 +12,7 @@ const NativeScriptVueTarget = require('nativescript-vue-target');
 require('./prepare')();
 
 // Generate platform-specific webpack configuration
-const config = (platform, launchArgs) => {
+const config = (platform, launchArgs = '') => {
 
   const command = launchArgs.split(' ')[0];
   const isDebug = command !== 'build';


### PR DESCRIPTION
When running some tasks like ```npm run watch``` process exits with 

```
error: uncaughtException: Cannot read property 'split' of undefined
```
