### PR TITLE
webpack: better configuration for production mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,17 +15,36 @@ cd <project-name>
 # Install dependencies
 npm install
 
-# Build for production
+# Build
 tns build <platform> --bundle
-
-# Build, watch for changes and debug the application
-tns debug <platform> --bundle
 
 # Build, watch for changes and run the application
 tns run <platform> --bundle
 
 # Clean the NativeScript application instance
 tns platform remove <platform>
+```
+
+### Debugging vs Production
+
+During usual run, project runs with following settings -
+
+1. Code is **not** minified
+2. Vue.config.silent is false, so every component creation is logged
+
+```bash
+# Build, watch for changes and debug the application
+tns debug <platform> --bundle
+```
+
+To minify code, and prevent Vue logs -
+
+```bash
+# Build for production
+tns build <platform> --bundle --env.production
+
+# Run as production
+tns run <platform> --bundle --env.production
 ```
 
 ## Using NativeScript plugins

--- a/template/app/main.js
+++ b/template/app/main.js
@@ -17,7 +17,7 @@ import store from './store';
 import './styles.scss';
 
 // Prints Vue logs when --env.production is *NOT* set while building
-Vue.config.silent = !DEBUG_MODE;
+Vue.config.silent = (TNS_ENV === 'production');
 
 new Vue({
 

--- a/template/app/main.js
+++ b/template/app/main.js
@@ -16,8 +16,8 @@ import store from './store';
 
 import './styles.scss';
 
-// Uncomment the following to see NativeScript-Vue output logs
-//Vue.config.silent = false;
+// Prints Vue logs when --env.production is *NOT* set while building
+Vue.config.silent = !DEBUG_MODE;
 
 new Vue({
 

--- a/template/app/store/index.js
+++ b/template/app/store/index.js
@@ -11,7 +11,7 @@ const store = new Vuex.Store({
   modules: {
     counter,
   },
-  strict: DEBUG_MODE,
+  strict: (TNS_ENV === 'debug'),
 });
 
 Vue.prototype.$store = store;

--- a/template/app/store/index.js
+++ b/template/app/store/index.js
@@ -11,7 +11,7 @@ const store = new Vuex.Store({
   modules: {
     counter,
   },
-  strict: debug,
+  strict: DEBUG_MODE,
 });
 
 Vue.prototype.$store = store;

--- a/template/webpack.config.js
+++ b/template/webpack.config.js
@@ -42,7 +42,7 @@ module.exports = env => {
 
             // You can provide the following flags when running 'tns run android|ios'
             snapshot, // --env.snapshot
-            uglify, // --env.uglify
+            production, // --env.production
             report, // --env.report
     } = env;
 
@@ -54,7 +54,7 @@ module.exports = env => {
     console.log(`Bundling application for entryPath ${entryPath}...`);
 
     const config = {
-        mode: uglify ? "production" : "development",
+        mode: production ? "production" : "development",
         context: appFullPath,
         watchOptions: {
             ignored: [
@@ -120,7 +120,7 @@ module.exports = env => {
                     },
                 },
             },
-            minimize: Boolean(uglify),
+            minimize: Boolean(production),
             minimizer: [
                 new UglifyJsPlugin({
                     uglifyOptions: {
@@ -192,6 +192,7 @@ module.exports = env => {
             // Define useful constants like TNS_WEBPACK
             new webpack.DefinePlugin({
                 "global.TNS_WEBPACK": "true",
+                "DEBUG_MODE": !production
             }),
             // Remove all files from the out dir.
             new CleanWebpackPlugin([`${dist}/**/*`]),

--- a/template/webpack.config.js
+++ b/template/webpack.config.js
@@ -192,7 +192,7 @@ module.exports = env => {
             // Define useful constants like TNS_WEBPACK
             new webpack.DefinePlugin({
                 "global.TNS_WEBPACK": "true",
-                "DEBUG_MODE": !production
+                "TNS_ENV": production ? "production" : "debug"
             }),
             // Remove all files from the out dir.
             new CleanWebpackPlugin([`${dist}/**/*`]),


### PR DESCRIPTION
Via Webpack define plugin we define a global key "DEBUG_MODE"
The value of DEBUG_MODE is true by default,
it's value is true when build is run with `--env.production`

To build a production bundle -
`tns build <platform> --bundle --env.production`

The DEBUG_MODE key controls the following -

 1. minify code (when DEBUG_MODE=false)
 2. show Vue logs (when DEBUG_MODE=true)
 3. Use strict mode in Vuex (when DEBUG_MODE=true)

Signed-off-by: Arnav Gupta <arnav@codingblocks.com>