### PR TITLE
fix: vue-hot-reload-api workaround on windows

### DIFF
--- a/template/webpack.config.js
+++ b/template/webpack.config.js
@@ -165,7 +165,7 @@ module.exports = env => {
 
                 // TODO: Removed the rule once https://github.com/vuejs/vue-hot-reload-api/pull/70 is accepted
                 {
-                    test: /vue-hot-reload-api\/dist\/index\.js$/,
+                    test: resolve(__dirname, 'node_modules/vue-hot-reload-api/dist/index.js'),
                     use: "../vue-hot-reload-api-patcher"
                 },
 


### PR DESCRIPTION
Currently the vue-hot-reload-api workaround does not work on windows because the hard coded path separator `/` is used inside the test regex. This pull request fixes this.

see https://github.com/webpack/webpack/issues/2073#issuecomment-186286504