### PR TITLE
Update package.json

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -37,7 +37,7 @@
     "css-loader": "^1.0.0",
     "lazy": "1.0.11",
     "mini-css-extract-plugin": "^0.4.1",
-    "nativescript-dev-webpack": "^0.17.0-2018-09-12-01",
+    "nativescript-dev-webpack": "0.17.0-2018-09-15-02",
     "nativescript-vue-template-compiler": "^2.0.0-alpha.3",
     "nativescript-worker-loader": "~0.9.0",
     "node-sass": "^4.9.2",


### PR DESCRIPTION
latest nativescript-dev-webpack```0.17.0-2018-09-17-01``` does not have ```style-hot-loader.js``` .
But ```0.17.0-2018-09-15-02``` has it.
[https://github.com/NativeScript/nativescript-dev-webpack/issues/665](https://github.com/NativeScript/nativescript-dev-webpack/issues/665)