### PR TITLE
Remove vue-hot-reload-api-patcher as it is not needed anymore

### DIFF
--- a/template/vue-hot-reload-api-patcher.js
+++ b/template/vue-hot-reload-api-patcher.js
@@ -1,5 +1,0 @@
-// TODO: Removed the file once https://github.com/vuejs/vue-hot-reload-api/pull/70 is accepted
-module.exports = function (source) {
-    return `var window = {};
-${source};`;
-};

--- a/template/webpack.config.js
+++ b/template/webpack.config.js
@@ -162,13 +162,6 @@ module.exports = env => {
                         },
                     ].filter(loader => Boolean(loader)),
                 },
-
-                // TODO: Removed the rule once https://github.com/vuejs/vue-hot-reload-api/pull/70 is accepted
-                {
-                    test: resolve(__dirname, 'node_modules/vue-hot-reload-api/dist/index.js'),
-                    use: "../vue-hot-reload-api-patcher"
-                },
-
                 {
                     test: /\.css$/,
                     use: [


### PR DESCRIPTION
The vue-hot-reload-api now [works for non-browsers](https://github.com/vuejs/vue-hot-reload-api/pull/70)