### PR TITLE
Fix action bar color according to the theme selected.

### DIFF
--- a/template/app/App_Resources/Android/src/main/res/values/colors.xml
+++ b/template/app/App_Resources/Android/src/main/res/values/colors.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <color name="ns_primary">#F5F5F5</color>
-    <color name="ns_primaryDark">#53ba82</color>
+    <color name="ns_primaryDark">#000</color>
     <color name="ns_accent">#33B5E5</color>
     <color name="ns_blue">#272734</color>
 </resources>

--- a/template/app/components/App.vue
+++ b/template/app/components/App.vue
@@ -1,6 +1,6 @@
 {{#if_eq preset "Simple"}}<template>
-    <Page>
-        <ActionBar title="Welcome to NativeScript-Vue!"/>
+    <Page class="page">
+        <ActionBar title="Welcome to NativeScript-Vue!" class="action-bar"/>
         <GridLayout colums="*" rows="*">
             <Label class="message" :text="msg" col="0" row="0"/>
         </GridLayout>
@@ -18,11 +18,6 @@
 </script>
 
 <style scoped>
-    ActionBar {
-        background-color: #53ba82;
-        color: #ffffff;
-    }
-
     .message {
         vertical-align: center;
         text-align: center;


### PR DESCRIPTION
Fixes #98.

Even if in the future you remove the `nativescript-theme-core` (replacing with `ns-tailwind`? ;) ), right now it is pretty confusing. I just lost an embarrassing amount of time because I picked the theme 'forest' and just assumed that the action bar color was coming from the theme...

Anyway, this is a small fix that I think improves the current template.