### PR TITLE
chore: update failing dependency

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -35,7 +35,7 @@
     "copy-webpack-plugin": "^4.5.2",
     "css-loader": "^1.0.0",
     "lazy": "1.0.11",
-    "nativescript-dev-webpack": "next",
+    "nativescript-dev-webpack": "0.22.0-next-2019-05-09-101045-01",
     "nativescript-vue-template-compiler": "^2.0.0",
     "nativescript-worker-loader": "~0.9.0",
     "node-sass": "^4.9.2",


### PR DESCRIPTION
With the version of nativescript-dev-webpack set to 'next', npm install fails as it can't find that version.

Running `npm view nativescript-dev-webpack versions --json|grep next` shows 0.22.0-next-2019-05-09-101045-01