### PR TITLE
fix missing store import when devtools disabled

### DIFF
--- a/template/app/main.js
+++ b/template/app/main.js
@@ -1,9 +1,10 @@
 import Vue from 'nativescript-vue'
 import App from './components/App'
 
-{{#devtools}}import VueDevtools from 'nativescript-vue-devtools'
+{{#devtools}}import VueDevtools from 'nativescript-vue-devtools'{{/devtools}}
 {{#store}}import store from './store'{{/store}}
 
+{{#devtools}}
 if(TNS_ENV !== 'production') {
   Vue.use(VueDevtools)
 }

--- a/template/app/main.ts
+++ b/template/app/main.ts
@@ -1,9 +1,10 @@
 import Vue from 'nativescript-vue'
 import App from './components/App'
 
-{{#devtools}}import VueDevtools from 'nativescript-vue-devtools'
+{{#devtools}}import VueDevtools from 'nativescript-vue-devtools'{{/devtools}}
 {{#store}}import store from './store'{{/store}}
 
+{{#devtools}}
 if(TNS_ENV !== 'production') {
   Vue.use(VueDevtools)
 }


### PR DESCRIPTION
Currently if you skip the `devtools` option `store` doesn't get imported.