### PR TITLE
Updated main scripts to load store before devtools

### DIFF
--- a/template/app/main.js
+++ b/template/app/main.js
@@ -1,8 +1,8 @@
 import Vue from 'nativescript-vue'
 import App from './components/App'
 
-{{#devtools}}import VueDevtools from 'nativescript-vue-devtools'{{/devtools}}
 {{#store}}import store from './store'{{/store}}
+{{#devtools}}import VueDevtools from 'nativescript-vue-devtools'{{/devtools}}
 
 {{#devtools}}
 if(TNS_ENV !== 'production') {

--- a/template/app/main.ts
+++ b/template/app/main.ts
@@ -1,8 +1,8 @@
 import Vue from 'nativescript-vue'
 import App from './components/App'
 
-{{#devtools}}import VueDevtools from 'nativescript-vue-devtools'{{/devtools}}
 {{#store}}import store from './store'{{/store}}
+{{#devtools}}import VueDevtools from 'nativescript-vue-devtools'{{/devtools}}
 
 {{#devtools}}
 if(TNS_ENV !== 'production') {


### PR DESCRIPTION
I was following this tutorial:
https://www.nativescript.org/blog/nativescript-vue-with-class-components

I ran into an error "HTMLElement is not defined" after generating the project with devtools enabled.

I found the below stackoverflow question / answer and it worked for me.
https://stackoverflow.com/a/58753786/696180

Forgive me if I overlooked something but it didn't seem to cause any issues when I made the fix manually.