### PR TITLE
rebased from master 

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,26 @@ tns run
 
 # Clean the NativeScript application instance
 tns platform remove <platform>
+
+# Hot Module Replacement (HMR) disabled Debugging session 
+tns debug <platform> --no-hmr
 ```
+<details><summary>Yarn usage</summary>
+<p>
+
+``` bash
+# Scaffold project
+yarn global add @vue/cli @vue/cli-init
+vue init nativescript-vue/vue-cli-template <project-name>
+cd <project-name>
+
+# Install dependencies
+yarn
+
+```
+
+</p>
+</details>
 
 ### Debugging vs Production
 

--- a/template/package.json
+++ b/template/package.json
@@ -15,14 +15,14 @@
     }
   },
   "dependencies": { {{#store}}
-    "vuex": "^3.1.1",{{/store}}{{#devtools}}
+    "vuex": "^3.3.0",{{/store}}{{#devtools}}
     "@vue/devtools": "^5.3.3",
     "nativescript-socketio": "^3.3.1",
     "nativescript-vue-devtools": "^1.4.0",
     "nativescript-toasty": "^3.0.0-alpha.2",{{/devtools}}{{#if_eq preset "SideDrawer"}}
     "nativescript-ui-sidedrawer": "^8.0.1",{{/if_eq}}{{#unless_eq color_scheme "none"}}
     "@nativescript/theme": "^2.2.1",{{/unless_eq}}
-    "nativescript-vue": "^2.6.0",
+    "nativescript-vue": "^2.6.1",
     "tns-core-modules": "^6.5.1"
   },
   "devDependencies": {


### PR DESCRIPTION
```
"vuex": "^3.3.0"
 "nativescript-vue": "^2.6.1
```
I have added `tns debug <platform> --no-hmr `to README.md because it was one of the most needed commands.
 Also for yarn users, I added a collapsable area.